### PR TITLE
Fix training script initialization error

### DIFF
--- a/main.py
+++ b/main.py
@@ -314,9 +314,11 @@ class LeapTradingSystem:
 
             # Get features for prediction
             if predictor is not None and len(data) >= self.config.data.lookback_window:
-                # Prepare input
+                # Prepare input - include OHLCV + computed features to match training
                 recent_data = data.tail(self.config.data.lookback_window)
-                features = recent_data[market_data.feature_names].values if market_data.feature_names else None
+                ohlcv_cols = ['open', 'high', 'low', 'close', 'volume']
+                feature_cols = ohlcv_cols + (list(market_data.feature_names) if market_data.feature_names else [])
+                features = recent_data[feature_cols].values
 
                 if features is not None:
                     # Make prediction


### PR DESCRIPTION
…input

The training pipeline includes OHLCV (5 features) concatenated with computed features (80) for 85 total dimensions, but the backtest strategy only passed computed features (80 dims). This caused RuntimeError: mat1 and mat2 shapes cannot be multiplied (120x80 and 85x128) when the predictor's input projection layer expected 85-dim input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced backtest strategy feature preparation to include both OHLCV data and computed features, providing the prediction model with more complete market context during backtesting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->