### PR TITLE
Add UNUSED comments and mark dead code in gap analysis

### DIFF
--- a/core/order_manager.py
+++ b/core/order_manager.py
@@ -475,6 +475,7 @@ class OrderManager:
 
         return executions
 
+    # UNUSED - Placeholder method, always returns empty list
     def get_pending_orders(self) -> List[OrderExecution]:
         """Get executions that are pending (for async systems)."""
         # In this implementation, all orders are synchronous

--- a/core/position_sync.py
+++ b/core/position_sync.py
@@ -454,6 +454,8 @@ class PositionTracker:
         pos = self._positions[ticket]
 
         # Update unrealized PnL using contract size
+        # BUG: TrackedPosition dataclass doesn't have contract_size attribute
+        # hasattr check always returns False, defaults to 100000
         contract_size = pos.contract_size if hasattr(pos, 'contract_size') and pos.contract_size else 100000
         if pos.is_long:
             pos.unrealized_pnl = (current_price - pos.entry_price) * pos.volume * contract_size

--- a/evaluation/backtester.py
+++ b/evaluation/backtester.py
@@ -754,6 +754,7 @@ class WalkForwardOptimizer:
         }
 
 
+# UNUSED - Class defined but never instantiated or exported in __init__.py
 class MonteCarloSimulator:
     """
     Monte Carlo simulation for risk analysis.

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -1,11 +1,17 @@
+# UNUSED - This entire module is not imported anywhere in the codebase
+# Also contains bugs: mt5.datetime doesn't exist, symbol_info.timezone doesn't exist
+
 import pandas as pd
 import MetaTrader5 as mt5
 
+
+# UNUSED - Function never called anywhere in codebase
 def load_data(file_path):
     data = pd.read_csv(file_path)
     return data
 
 
+# UNUSED - Function never called anywhere in codebase
 def get_historical_data(symbol, timeframe, start, end):
     mt5.initialize()
 

--- a/utils/logging_config.py
+++ b/utils/logging_config.py
@@ -7,7 +7,7 @@ import logging
 import os
 import sys
 from datetime import datetime
-from logging.handlers import RotatingFileHandler, TimedRotatingFileHandler
+from logging.handlers import RotatingFileHandler, TimedRotatingFileHandler  # UNUSED: TimedRotatingFileHandler
 from typing import Optional
 
 


### PR DESCRIPTION
Mark unused code discovered during codebase analysis:
- utils/data_utils.py: Entire module unused and contains bugs
- utils/logging_config.py: TimedRotatingFileHandler import unused
- evaluation/backtester.py: MonteCarloSimulator class never used
- core/order_manager.py: get_pending_orders() placeholder method
- core/position_sync.py: Document bug where contract_size attribute
  doesn't exist on TrackedPosition dataclass