### PR TITLE
Fix SSL warning during model training

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,15 @@ Leap Trading System - Main Orchestrator
 Command-line interface and main entry point for the trading system.
 """
 
+# Suppress urllib3 SSL warning for LibreSSL compatibility (macOS)
+# This must be done before any imports that load urllib3
+import warnings
+try:
+    from urllib3.exceptions import NotOpenSSLWarning
+    warnings.filterwarnings("ignore", category=NotOpenSSLWarning)
+except ImportError:
+    pass  # urllib3 < 2.0 doesn't have NotOpenSSLWarning
+
 import argparse
 import sys
 import os


### PR DESCRIPTION
- Add batched validation in TransformerPredictor._validate() to prevent GPU memory exhaustion on Apple Silicon MPS backend during training
- Suppress urllib3 NotOpenSSLWarning for LibreSSL compatibility on macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory efficiency during model validation on GPU and MPS devices through batched processing.

* **Chores**
  * Suppressed LibreSSL-related SSL warnings on macOS to reduce console noise.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->