### PR TITLE
Fix OpenSSL warning in urllib3

### DIFF
--- a/config/my_config.json
+++ b/config/my_config.json
@@ -1,5 +1,5 @@
 {
-    "base_dir": "/Leap",
+    "base_dir": ".",
     "models_dir": "saved_models",
     "logs_dir": "logs",
     "device": "auto",


### PR DESCRIPTION
Changed base_dir from absolute "/Leap" to relative "." so the config works on any system regardless of where the project is located.