### PR TITLE
Create architecture documentation and refactoring plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,9 @@ python main.py backtest --symbol EURUSD --bars 50000
 python main.py backtest --symbol EURUSD --realistic --monte-carlo
 python main.py walkforward --symbol EURUSD
 
-# Live Trading
-python main.py live --paper                              # Paper trading
-python main.py autotrade --paper --symbol EURUSD         # Auto-trader with MT5 (Windows only)
+# Live Trading (Windows only - requires MT5)
+python main.py autotrade --paper                         # Paper trading mode
+python main.py autotrade --paper --symbol EURUSD         # Paper trading with specific symbol
 
 # Evaluation
 python main.py evaluate --model-dir ./saved_models
@@ -349,7 +349,7 @@ The `OnlineLearningManager` monitors and adapts models:
 
 - **NumPy Version**: Must be <2.0 for PyTorch ABI compatibility
 - **MT5 Integration**: Only works on Windows; use paper mode on other platforms
-- **Safety**: Always use `--paper` flag when testing live trading
+- **Safety**: Always use `--paper` flag when testing `autotrade` command
 - **Model Files**: Saved to `saved_models/` with `model_metadata.json` for reloading
 - **Logging**: Logs rotate by size (10MB default) with 5 backups
 - **MLflow**: Experiments tracked in `mlruns/` directory
@@ -363,9 +363,8 @@ See `CLI.md` for detailed command documentation.
 | `train` | Train Transformer + PPO models |
 | `backtest` | Run backtest with optional Monte Carlo |
 | `walkforward` | Walk-forward optimization |
-| `live` | Start live/paper trading session |
 | `evaluate` | Evaluate trained models |
-| `autotrade` | Start autonomous MT5 trading |
+| `autotrade` | Start autonomous MT5 trading (live/paper) |
 
 **Global options:** `--symbol`, `--timeframe`, `--bars`, `--model-dir`, `--config`, `--log-level`, `--paper`
 

--- a/CLI.md
+++ b/CLI.md
@@ -17,7 +17,6 @@ python main.py [COMMAND] [OPTIONS]
 | `train` | Train Transformer predictor and PPO reinforcement learning agent |
 | `backtest` | Run backtest on historical market data |
 | `walkforward` | Run walk-forward optimization with rolling train/test splits |
-| `live` | Start live or paper trading session |
 | `evaluate` | Evaluate trained models on test data |
 | `autotrade` | Start auto-trader with MetaTrader5 integration (Windows only) |
 
@@ -177,40 +176,6 @@ python main.py walkforward --symbol EURUSD
 
 # Walk-forward with extended data
 python main.py walkforward --symbol GBPUSD --bars 100000
-```
-
----
-
-### live
-
-Start a live or paper trading session.
-
-**Syntax:**
-```bash
-python main.py live [OPTIONS]
-```
-
-**Options:**
-
-| Option | Short | Type | Default | Description |
-|--------|-------|------|---------|-------------|
-| `--symbol` | `-s` | string | `EURUSD` | Trading symbol |
-| `--timeframe` | `-t` | string | `1h` | Timeframe for data |
-| `--model-dir` | `-m` | string | `./saved_models` | Directory to load trained models from |
-| `--paper` | | flag | `False` | Enable paper trading mode (simulated trades) |
-| `--config` | `-c` | string | | Path to configuration JSON file |
-| `--log-level` | `-l` | choice | | Logging level: DEBUG, INFO, WARNING, ERROR |
-| `--log-file` | | string | | Custom log file path |
-
-> **Warning:** Always use `--paper` flag when testing to avoid real money trades.
-
-**Examples:**
-```bash
-# Paper trading (recommended for testing)
-python main.py live --paper
-
-# Paper trading with specific symbol
-python main.py live --paper --symbol GBPUSD --timeframe 4h
 ```
 
 ---
@@ -471,8 +436,8 @@ Leap/
 ## Important Notes
 
 ### Safety
-- **Always use `--paper` flag** when testing live or autotrade commands
-- Live trading with real money requires explicit confirmation
+- **Always use `--paper` flag** when testing autotrade commands
+- Real money trading requires explicit confirmation
 - Never share or commit MT5 credentials
 
 ### Platform Requirements
@@ -513,8 +478,8 @@ python main.py backtest --symbol EURUSD --realistic --monte-carlo
 # 4. Run walk-forward optimization
 python main.py walkforward --symbol EURUSD --bars 100000
 
-# 5. Paper trade to validate
-python main.py live --paper --symbol EURUSD
+# 5. Paper trade to validate (Windows only - requires MT5)
+python main.py autotrade --paper --symbol EURUSD
 ```
 
 ### Using Custom Configuration

--- a/README.md
+++ b/README.md
@@ -405,20 +405,12 @@ python main.py walkforward --symbol EURUSD
 python main.py evaluate --model-dir ./saved_models
 ```
 
-### Live Trading
-
-```bash
-# Paper trading (simulated)
-python main.py live --paper
-
-# Live trading (requires MT5 connection)
-python main.py live
-```
-
-### Auto-Trading (Autonomous)
+### Live/Auto-Trading
 
 The auto-trader runs autonomously, combining Transformer predictions with PPO agent decisions.
 See [docs/AUTO_TRADER.md](docs/AUTO_TRADER.md) for detailed documentation.
+
+> **Note:** Live trading requires Windows with MetaTrader 5 integration.
 
 ```bash
 # Paper trading mode (recommended for testing)

--- a/docs/ARCHITECTURAL_MISMATCH_REPORT.md
+++ b/docs/ARCHITECTURAL_MISMATCH_REPORT.md
@@ -1905,7 +1905,16 @@ Create unified interface per the interface definitions above.
 - [x] MINOR-4: Remove unused get_logger() function ✅ **COMPLETED**
 - [x] Create TradingError exception hierarchy ✅ **COMPLETED**
 
-#### Phase 4 (Future Work)
+#### Phase 4 (Completed) - Feature Implementation Mismatches
+- [x] FEATURE-CRITICAL-1: Remove incomplete `live` command stub ✅ **COMPLETED**
+- [x] FEATURE-MAJOR-1: Eliminate CLI confusion (removed `live`, kept `autotrade`) ✅ **COMPLETED**
+- [x] FEATURE-MAJOR-2: Documented that LiveTradingEnvironment is used by AutoTrader only ✅ **COMPLETED**
+- [x] Update CLI.md to remove `live` command documentation ✅ **COMPLETED**
+- [x] Update CLAUDE.md to remove `live` command references ✅ **COMPLETED**
+- [x] Update README.md to consolidate live trading docs ✅ **COMPLETED**
+- [x] Update tests to remove `live` command tests ✅ **COMPLETED**
+
+#### Phase 5 (Future Work)
 - [ ] Add integration tests for dimension matching
 - [ ] MAJOR-3: Configuration passing consistency (optional - documented as design decision)
 - [ ] Documentation reorganization (cross-references, etc.)
@@ -2023,7 +2032,17 @@ The codebase uses three configuration passing styles:
    - `DataPipelineError` - Data fetching/processing errors
    - `RiskLimitExceededError` - Risk limit exceeded
 
+### Phase 4 (FEATURE Implementation Mismatches)
+1. **FEATURE-CRITICAL-1**: Removed incomplete `live` command stub (`start_live_trading()` method)
+2. **FEATURE-MAJOR-1**: Eliminated CLI confusion by removing `live` command - `autotrade` is now the single production implementation
+3. **FEATURE-MAJOR-2**: Documented that `LiveTradingEnvironment` is intentionally used only by `AutoTrader`
+
 ### Files Modified
+- `main.py` - Removed `start_live_trading()` method, removed `'live'` from CLI choices, updated examples
+- `tests/test_cli.py` - Removed `'live'` from test parsers, removed `test_live_command_args` and `test_live_trading_without_models`
+- `CLI.md` - Removed `live` command section and references
+- `CLAUDE.md` - Updated CLI reference table and examples
+- `README.md` - Consolidated live trading documentation into autotrade section
 - `core/live_trading_env.py` - MAJOR-1, MAJOR-2, MINOR-1 fixes
 - `models/ppo_agent.py` - MAJOR-5 fix (LR scheduler)
 - `training/online_interface.py` - MAJOR-7 fix (new file)
@@ -2038,4 +2057,4 @@ The codebase uses three configuration passing styles:
 
 *Report updated: 2025-12-10*
 *Analysis scope: Full codebase architectural review with refactoring plan*
-*Implementation status: Phase 1, Phase 2, and Phase 3 (MINOR) COMPLETED*
+*Implementation status: Phase 1, Phase 2, Phase 3 (MINOR), and Phase 4 (FEATURE) COMPLETED*

--- a/main.py
+++ b/main.py
@@ -595,37 +595,6 @@ class LeapTradingSystem:
 
         return results
 
-    def start_live_trading(self, paper: bool = True):
-        """Start live trading (paper or real)."""
-        mode = 'paper' if paper else 'live'
-        logger.info(f"Starting {mode} trading...")
-
-        # Ensure models are loaded
-        if self._predictor is None or self._agent is None:
-            logger.error("Models not loaded. Please train or load models first.")
-            return
-
-        # Create online learning manager
-        self._online_manager = OnlineLearningManager(
-            predictor=self._predictor,
-            agent=self._agent
-        )
-
-        # Main trading loop would go here
-        logger.info(f"{mode.capitalize()} trading started. Press Ctrl+C to stop.")
-
-        try:
-            while True:
-                # Get latest market data
-                # Make prediction
-                # Execute trades
-                # Online learning updates
-                import time
-                time.sleep(1)
-
-        except KeyboardInterrupt:
-            logger.info("Trading stopped by user")
-
     def save_models(self, directory: Optional[str] = None):
         """Save all models."""
         if directory is None:
@@ -769,14 +738,14 @@ def main():
 Examples:
   python main.py train --symbol EURUSD --epochs 100
   python main.py backtest --symbol EURUSD
-  python main.py live --paper
+  python main.py autotrade --paper
   python main.py evaluate --model-dir ./models
         """
     )
 
     parser.add_argument(
         'command',
-        choices=['train', 'backtest', 'live', 'evaluate', 'walkforward', 'autotrade'],
+        choices=['train', 'backtest', 'evaluate', 'walkforward', 'autotrade'],
         help='Command to execute'
     )
 
@@ -1098,10 +1067,6 @@ Examples:
 
         results = system.walk_forward_test(market_data)
         print(json.dumps(results, indent=2, default=str))
-
-    elif args.command == 'live':
-        system.load_models(args.model_dir)
-        system.start_live_trading(paper=args.paper)
 
     elif args.command == 'evaluate':
         logger.info("Evaluating models...")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -488,7 +488,7 @@ class TestCLIArgumentParsing:
 
         with patch.object(sys, 'argv', ['main.py'] + test_args):
             parser = argparse.ArgumentParser()
-            parser.add_argument('command', choices=['train', 'backtest', 'live', 'evaluate', 'walkforward', 'autotrade'])
+            parser.add_argument('command', choices=['train', 'backtest', 'evaluate', 'walkforward', 'autotrade'])
             parser.add_argument('--symbol', '-s', default='EURUSD')
             parser.add_argument('--epochs', '-e', type=int, default=100)
 
@@ -503,7 +503,7 @@ class TestCLIArgumentParsing:
         test_args = ['backtest', '--symbol', 'EURUSD', '--bars', '10000', '--realistic']
 
         parser = argparse.ArgumentParser()
-        parser.add_argument('command', choices=['train', 'backtest', 'live', 'evaluate', 'walkforward', 'autotrade'])
+        parser.add_argument('command', choices=['train', 'backtest', 'evaluate', 'walkforward', 'autotrade'])
         parser.add_argument('--symbol', '-s', default='EURUSD')
         parser.add_argument('--bars', '-b', type=int, default=50000)
         parser.add_argument('--realistic', action='store_true')
@@ -514,17 +514,17 @@ class TestCLIArgumentParsing:
         assert args.bars == 10000
         assert args.realistic is True
 
-    def test_live_command_args(self):
-        """Test live command argument parsing."""
-        test_args = ['live', '--paper']
+    def test_autotrade_command_args(self):
+        """Test autotrade command argument parsing."""
+        test_args = ['autotrade', '--paper']
 
         parser = argparse.ArgumentParser()
-        parser.add_argument('command', choices=['train', 'backtest', 'live', 'evaluate', 'walkforward', 'autotrade'])
+        parser.add_argument('command', choices=['train', 'backtest', 'evaluate', 'walkforward', 'autotrade'])
         parser.add_argument('--paper', action='store_true')
 
         args = parser.parse_args(test_args)
 
-        assert args.command == 'live'
+        assert args.command == 'autotrade'
         assert args.paper is True
 
     def test_mlflow_args(self):
@@ -532,7 +532,7 @@ class TestCLIArgumentParsing:
         test_args = ['train', '--no-mlflow', '--mlflow-experiment', 'test_exp']
 
         parser = argparse.ArgumentParser()
-        parser.add_argument('command', choices=['train', 'backtest', 'live', 'evaluate', 'walkforward', 'autotrade'])
+        parser.add_argument('command', choices=['train', 'backtest', 'evaluate', 'walkforward', 'autotrade'])
         parser.add_argument('--no-mlflow', action='store_true')
         parser.add_argument('--mlflow-experiment', default=None)
 
@@ -680,16 +680,6 @@ class TestEdgeCases:
             result = trading_system.load_data('INVALID', '1h', 1000)
 
             assert result is None
-
-    def test_live_trading_without_models(self, trading_system):
-        """Test that live trading fails gracefully without models."""
-        # Models are None by default
-        assert trading_system._predictor is None
-        assert trading_system._agent is None
-
-        # start_live_trading should handle this gracefully (logs error and returns)
-        trading_system.start_live_trading(paper=True)
-        # Should not crash - method logs error via logger and returns early
 
     def test_save_models_without_predictor(self, trading_system, temp_dir):
         """Test save_models with only agent."""


### PR DESCRIPTION
BREAKING CHANGE: The `live` command has been removed. Use `autotrade` instead.

This commit addresses FEATURE-CRITICAL-1 and FEATURE-MAJOR-1 from the architectural mismatch report. The `live` command was an incomplete stub that created components but never used them, while `autotrade` is the full production-ready implementation.

Changes:
- Remove `start_live_trading()` method from LeapTradingSystem (main.py)
- Remove `live` from CLI command choices
- Update tests to use `autotrade` instead of `live`
- Update CLI.md, CLAUDE.md, README.md documentation
- Mark FEATURE fixes as completed in ARCHITECTURAL_MISMATCH_REPORT.md

Migration: Users should replace `python main.py live --paper` with `python main.py autotrade --paper`. Note that autotrade requires Windows with MetaTrader 5 integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The `live` trading command has been removed. Use `autotrade` instead for both paper and live trading modes.
  * Live trading functionality now requires Windows operating system with MT5 integration.

* **Documentation**
  * Updated documentation, reference guides, and examples to reflect the consolidated autotrade workflow.
  * Added Windows and MT5 integration requirement notes throughout relevant guides.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->