### PR TITLE
Fix backtest warning in main script

### DIFF
--- a/main.py
+++ b/main.py
@@ -455,10 +455,14 @@ class LeapTradingSystem:
             'volume': market_data.volume
         })
 
-        # Add features
+        # Add features - use pd.concat to avoid DataFrame fragmentation
         if market_data.features is not None:
-            for i, name in enumerate(market_data.feature_names):
-                df[name] = market_data.features[:, i]
+            feature_dict = {
+                name: market_data.features[:, i]
+                for i, name in enumerate(market_data.feature_names)
+            }
+            feature_df = pd.DataFrame(feature_dict)
+            df = pd.concat([df, feature_df], axis=1)
 
         # Create backtester
         backtester = Backtester(


### PR DESCRIPTION
Replace loop that inserted feature columns one at a time with pd.concat to join all columns at once. This eliminates the PerformanceWarning about DataFrame fragmentation during backtest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized backtesting data handling by improving DataFrame assembly efficiency, reducing internal memory fragmentation for enhanced performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->