### PR TITLE
fix: migrate MLflow from filesystem to SQLite database backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,6 +207,9 @@ cython_debug/
 checkpoints/
 saved_models/
 mlruns/
+mlflow.db
+mlflow.db-shm
+mlflow.db-wal
 # Ruff stuff:
 .ruff_cache/
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -175,7 +175,9 @@ class LoggingConfig:
 class MLflowConfig:
     """MLflow experiment tracking configuration."""
     enabled: bool = True
-    tracking_uri: str = "mlruns"  # Local directory by default, can be remote URI
+    # Database backend (SQLite) - filesystem backend deprecated Feb 2026
+    # See: https://github.com/mlflow/mlflow/issues/18534
+    tracking_uri: str = "sqlite:///mlflow.db"
     experiment_name: str = "leap-trading"
     run_name_prefix: str = "training"
 

--- a/main.py
+++ b/main.py
@@ -1003,7 +1003,7 @@ Examples:
     parser.add_argument(
         '--mlflow-tracking-uri',
         default=None,
-        help='MLflow tracking URI (default: mlruns)'
+        help='MLflow tracking URI (default: sqlite:///mlflow.db)'
     )
 
     parser.add_argument(


### PR DESCRIPTION
The filesystem tracking backend (./mlruns) is deprecated in February 2026.
Migrate to SQLite database backend as recommended by MLflow.

Changes:
- Update default tracking_uri from "mlruns" to "sqlite:///mlflow.db"
- Add mlflow.db and related files to .gitignore
- Update CLI help text to reflect new default

See: https://github.com/mlflow/mlflow/issues/18534

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MLflow tracking configuration to use SQLite database backend, improving data persistence
  * Enhanced CLI help text to reflect new tracking URI default
  * Improved version control to exclude MLflow database and temporary files from repository

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->