### PR TITLE
Add MLflow launch button to UI dashboard

### DIFF
--- a/api/app/routes/system.py
+++ b/api/app/routes/system.py
@@ -1,8 +1,13 @@
 """System API routes."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 
-from ..schemas.system import HealthResponse, SystemMetricsResponse
+from ..schemas.system import (
+    HealthResponse,
+    MLflowLaunchResponse,
+    MLflowStatusResponse,
+    SystemMetricsResponse,
+)
 from ..services.system_service import system_service
 
 router = APIRouter(tags=["system"])
@@ -20,3 +25,17 @@ async def get_system_metrics():
     """Get system resource metrics."""
     metrics = system_service.get_metrics()
     return SystemMetricsResponse(data=metrics)
+
+
+@router.get("/mlflow/status", response_model=MLflowStatusResponse)
+async def get_mlflow_status(port: int = Query(default=5000, ge=1024, le=65535)):
+    """Get MLflow server status."""
+    status = system_service.get_mlflow_status(port=port)
+    return MLflowStatusResponse(data=status)
+
+
+@router.post("/mlflow/launch", response_model=MLflowLaunchResponse)
+async def launch_mlflow(port: int = Query(default=5000, ge=1024, le=65535)):
+    """Launch MLflow UI server."""
+    result = system_service.launch_mlflow(port=port)
+    return MLflowLaunchResponse(data=result)

--- a/api/app/schemas/system.py
+++ b/api/app/schemas/system.py
@@ -79,3 +79,33 @@ class HealthResponse(BaseModel):
     """Health check response."""
 
     data: HealthData
+
+
+class MLflowStatusData(BaseModel):
+    """MLflow status data."""
+
+    running: bool
+    url: Optional[str] = None
+    port: int = 5000
+    tracking_uri: str
+    experiment_name: str
+
+
+class MLflowStatusResponse(BaseModel):
+    """MLflow status response."""
+
+    data: MLflowStatusData
+
+
+class MLflowLaunchData(BaseModel):
+    """MLflow launch result data."""
+
+    success: bool
+    url: str
+    message: str
+
+
+class MLflowLaunchResponse(BaseModel):
+    """MLflow launch response."""
+
+    data: MLflowLaunchData

--- a/api/app/services/system_service.py
+++ b/api/app/services/system_service.py
@@ -2,7 +2,11 @@
 
 import logging
 import shutil
-from typing import Any
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Optional
 
 import psutil
 
@@ -14,8 +18,11 @@ from ..schemas.system import (
     GPUMetrics,
     HealthData,
     MemoryMetrics,
+    MLflowLaunchData,
+    MLflowStatusData,
     SystemMetricsData,
 )
+from ..core.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +131,149 @@ class SystemService:
             name=None,
             memory=None,
         )
+
+    def _is_port_in_use(self, port: int) -> bool:
+        """Check if a port is in use."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            return s.connect_ex(("localhost", port)) == 0
+
+    def _find_mlflow_process(self) -> Optional[psutil.Process]:
+        """Find running MLflow UI process."""
+        for proc in psutil.process_iter(["pid", "name", "cmdline"]):
+            try:
+                cmdline = proc.info.get("cmdline") or []
+                if any("mlflow" in str(arg).lower() for arg in cmdline):
+                    if any("ui" in str(arg).lower() or "server" in str(arg).lower() for arg in cmdline):
+                        return proc
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        return None
+
+    def get_mlflow_status(self, port: int = 5000) -> MLflowStatusData:
+        """Get MLflow server status."""
+        try:
+            import mlflow
+
+            # Get MLflow configuration
+            tracking_uri = "sqlite:///mlflow.db"  # Default from settings
+            experiment_name = "leap-trading"
+
+            try:
+                # Try to load from project config if available
+                sys.path.insert(0, str(settings.PROJECT_ROOT))
+                from config.settings import MLflowConfig
+                mlflow_config = MLflowConfig()
+                tracking_uri = mlflow_config.tracking_uri
+                experiment_name = mlflow_config.experiment_name
+            except Exception:
+                pass
+
+            # Check if MLflow server is running
+            running = self._is_port_in_use(port)
+            url = f"http://localhost:{port}" if running else None
+
+            return MLflowStatusData(
+                running=running,
+                url=url,
+                port=port,
+                tracking_uri=tracking_uri,
+                experiment_name=experiment_name,
+            )
+        except ImportError:
+            return MLflowStatusData(
+                running=False,
+                url=None,
+                port=port,
+                tracking_uri="",
+                experiment_name="",
+            )
+
+    def launch_mlflow(self, port: int = 5000) -> MLflowLaunchData:
+        """Launch MLflow UI server."""
+        try:
+            # Check if already running
+            if self._is_port_in_use(port):
+                return MLflowLaunchData(
+                    success=True,
+                    url=f"http://localhost:{port}",
+                    message="MLflow UI is already running",
+                )
+
+            # Get tracking URI from config
+            tracking_uri = "sqlite:///mlflow.db"
+            try:
+                sys.path.insert(0, str(settings.PROJECT_ROOT))
+                from config.settings import MLflowConfig
+                mlflow_config = MLflowConfig()
+                tracking_uri = mlflow_config.tracking_uri
+            except Exception:
+                pass
+
+            # Determine the database file path
+            db_path = settings.PROJECT_ROOT / "mlflow.db"
+            if tracking_uri.startswith("sqlite:///"):
+                db_file = tracking_uri.replace("sqlite:///", "")
+                if not Path(db_file).is_absolute():
+                    db_path = settings.PROJECT_ROOT / db_file
+
+            # Launch MLflow UI in background
+            cmd = [
+                sys.executable,
+                "-m",
+                "mlflow",
+                "ui",
+                "--backend-store-uri",
+                f"sqlite:///{db_path}",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                str(port),
+            ]
+
+            logger.info(f"Starting MLflow UI: {' '.join(cmd)}")
+
+            # Start the process
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=str(settings.PROJECT_ROOT),
+                start_new_session=True,
+            )
+
+            # Give it a moment to start
+            import time
+            time.sleep(2)
+
+            # Check if it started successfully
+            if process.poll() is None and self._is_port_in_use(port):
+                return MLflowLaunchData(
+                    success=True,
+                    url=f"http://localhost:{port}",
+                    message="MLflow UI started successfully",
+                )
+            else:
+                # Try to get error output
+                stderr = ""
+                try:
+                    _, stderr_bytes = process.communicate(timeout=1)
+                    stderr = stderr_bytes.decode() if stderr_bytes else ""
+                except Exception:
+                    pass
+
+                return MLflowLaunchData(
+                    success=False,
+                    url=f"http://localhost:{port}",
+                    message=f"Failed to start MLflow UI: {stderr or 'Unknown error'}",
+                )
+
+        except Exception as e:
+            logger.exception("Failed to launch MLflow UI")
+            return MLflowLaunchData(
+                success=False,
+                url=f"http://localhost:{port}",
+                message=f"Error launching MLflow: {str(e)}",
+            )
 
 
 system_service = SystemService()

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -160,6 +160,9 @@ export const logsApi = {
 export const systemApi = {
   health: () => fetchApi<HealthStatus>('/health'),
   metrics: () => fetchApi<SystemMetrics>('/metrics/system'),
+  mlflowStatus: () => fetchApi<MLflowStatus>('/mlflow/status'),
+  launchMlflow: () =>
+    fetchApi<MLflowLaunchResult>('/mlflow/launch', { method: 'POST' }),
 }
 
 // Types
@@ -353,4 +356,18 @@ export interface SystemMetrics {
   memory: { total: number; used: number; percent: number }
   gpu: { available: boolean; name?: string }
   disk: { total: number; used: number; percent: number }
+}
+
+export interface MLflowStatus {
+  running: boolean
+  url: string | null
+  port: number
+  tracking_uri: string
+  experiment_name: string
+}
+
+export interface MLflowLaunchResult {
+  success: boolean
+  url: string
+  message: string
 }


### PR DESCRIPTION
Add a button to the dashboard that allows users to launch and open the MLflow tracking UI in a new browser tab. The button shows a green indicator when MLflow is already running and automatically starts the server if needed.

Changes:
- Add MLflow status and launch API endpoints to system routes
- Add MLflowStatusData and MLflowLaunchData schemas
- Add service methods to check MLflow status and launch the UI server
- Add MLflow API client methods in the frontend
- Add MLflow button with status indicator to dashboard header