### PR TITLE
Investigate PPO agent GPU usage issue

### DIFF
--- a/core/trading_env_base.py
+++ b/core/trading_env_base.py
@@ -91,6 +91,7 @@ class BaseTradingEnvironment(gym.Env, ABC):
         self.take_profit_pct = config.take_profit_pct
         self.window_size = config.window_size
         self.max_drawdown_threshold = config.max_drawdown_threshold
+        self.max_episode_steps = config.max_episode_steps
 
         self.render_mode = render_mode
         self.risk_manager = risk_manager
@@ -108,6 +109,7 @@ class BaseTradingEnvironment(gym.Env, ABC):
         # State and step counter (initialized by subclass reset)
         self.state: TradingState = None
         self.current_step = 0
+        self._episode_step = 0  # Steps within current episode (for max_episode_steps)
 
         # Track previous drawdown for delta-based reward calculation
         # This enables penalizing drawdown INCREASES rather than cumulative drawdown

--- a/core/trading_types.py
+++ b/core/trading_types.py
@@ -129,6 +129,7 @@ class EnvConfig:
     take_profit_pct: float = 0.04  # 4% take profit
     window_size: int = 60
     max_drawdown_threshold: float = 0.5  # 50% max drawdown terminates episode
+    max_episode_steps: int = 2000  # Max steps per episode (prevents extremely long episodes)
 
     @classmethod
     def from_params(
@@ -142,7 +143,8 @@ class EnvConfig:
         stop_loss_pct: Optional[float] = None,
         take_profit_pct: Optional[float] = None,
         window_size: Optional[int] = None,
-        max_drawdown_threshold: Optional[float] = None
+        max_drawdown_threshold: Optional[float] = None,
+        max_episode_steps: Optional[int] = None
     ) -> 'EnvConfig':
         """
         Factory method to create EnvConfig from individual parameters.
@@ -164,7 +166,8 @@ class EnvConfig:
             stop_loss_pct=stop_loss_pct if stop_loss_pct is not None else defaults.stop_loss_pct,
             take_profit_pct=take_profit_pct if take_profit_pct is not None else defaults.take_profit_pct,
             window_size=window_size if window_size is not None else defaults.window_size,
-            max_drawdown_threshold=max_drawdown_threshold if max_drawdown_threshold is not None else defaults.max_drawdown_threshold
+            max_drawdown_threshold=max_drawdown_threshold if max_drawdown_threshold is not None else defaults.max_drawdown_threshold,
+            max_episode_steps=max_episode_steps if max_episode_steps is not None else defaults.max_episode_steps
         )
 
 


### PR DESCRIPTION
The PPO training was stuck at "Episodes: 0" after 20k+ timesteps because episodes only terminated when reaching end of 50,000 data points or on bankruptcy/max drawdown. This made each episode 50x longer than typical RL.

Changes:
- Add max_episode_steps (default: 2000) to EnvConfig
- Track _episode_step counter within each episode
- Set truncated=True when max_episode_steps reached
- Randomize episode starting point to sample different market regimes

Impact:
- Episodes now complete in ~2000 steps instead of 50,000
- PPO training will show episode completions and rewards
- Faster iteration and better learning from diverse market conditions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configurable maximum episode length parameter (default: 2000 steps)
  * Episodes now use randomized starting positions within safe data ranges to sample diverse market conditions

* **Improvements**
  * Clarified distinction between natural episode termination and step-count-based truncation for training clarity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->