### PR TITLE
refactor: deprecate standalone backtest command, keep walkforward

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,7 @@ Leap is an AI-powered forex trading system combining Transformer-based price pre
 python main.py train --symbol EURUSD --epochs 100 --timesteps 100000
 python main.py train --symbols EURUSD GBPUSD --multi-timeframe  # Multi-symbol + multi-timeframe
 
-# Backtesting
-python main.py backtest --symbol EURUSD --realistic --monte-carlo
+# Validation
 python main.py walkforward --symbol EURUSD
 
 # Live Trading (Windows only - requires MT5)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An advanced AI-powered forex trading system with online learning and adaptation 
 - **PPO Reinforcement Learning**: Proximal Policy Optimization agent for optimal trading decisions
 - **Online Learning**: Continuous model adaptation to changing market conditions
 - **Market Regime Detection**: Automatic detection of market states (trending, ranging, high volatility)
-- **Comprehensive Backtesting**: Walk-forward optimization and Monte Carlo simulation
+- **Walk-Forward Validation**: Rolling window train/test validation and Monte Carlo simulation
 - **Risk Management**: Dynamic position sizing, stop-loss/take-profit, and drawdown limits
 - **Multi-timeframe Analysis**: Feature engineering across multiple timeframes
 
@@ -81,7 +81,7 @@ For detailed technical architecture documentation including:
 - **Model Architecture**: Transformer Predictor and PPO Agent internals
 - **Data Flow**: Complete data pipeline and feature engineering details
 - **Online Learning**: Adaptation triggers and learning loops
-- **Walk-Forward Optimization**: Backtesting methodology
+- **Walk-Forward Optimization**: Validation methodology for strategy robustness
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for comprehensive diagrams and technical details.
 
@@ -181,20 +181,15 @@ python main.py train --symbols EURUSD GBPUSD --multi-timeframe
 
 > **Note:** Multi-timeframe training adds indicators from higher/lower timeframes as features (e.g., 1h training with 15m/4h/1d features). See [CLI.md](CLI.md) for detailed options.
 
-### Backtesting
+### Validation (Walk-Forward)
 
 ```bash
-# Run backtest on historical data
-python main.py backtest --symbol EURUSD --bars 50000
-
-# Backtest with realistic constraints (limited trades, capped position size)
-python main.py backtest --symbol EURUSD --realistic
-
-# Backtest with Monte Carlo risk analysis
-python main.py backtest --symbol EURUSD --monte-carlo
-
-# Walk-forward optimization
+# Walk-forward optimization (validates strategy robustness)
+# Trains fresh models per fold and tests on unseen data
 python main.py walkforward --symbol EURUSD
+
+# Walk-forward with more historical data (more folds)
+python main.py walkforward --symbol EURUSD --bars 100000
 ```
 
 ### Evaluation


### PR DESCRIPTION
Remove the standalone backtest CLI command and related functionality
while preserving the internal Backtester class that is required by
WalkForwardOptimizer for validation.

Changes:
- Remove `backtest` CLI command from main.py
- Remove `LeapTradingSystem.backtest()` method
- Remove `--realistic` and `--monte-carlo` CLI flags
- Remove unused PerformanceAnalyzer import
- Update CLI.md, CLAUDE.md, README.md documentation
- Remove TestBacktest class and related tests from test_cli.py

The walkforward command remains the recommended approach for strategy
validation as it trains fresh models per fold and tests on unseen data,
providing more robust validation than standalone backtesting.

Preserved (required by walkforward):
- Backtester class (used internally by WalkForwardOptimizer)
- BacktestResult dataclass
- MetricsCalculator and PerformanceAnalyzer classes
- BacktestConfig (contains walk_forward_* settings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Walk-forward validation is now the primary strategy validation method, replacing backtesting. Each fold trains fresh models and tests on unseen data.

* **Documentation**
  * Updated CLI commands, usage examples, and documentation to reflect walk-forward validation terminology.

* **Chores**
  * Removed deprecated backtesting functionality and related CLI options (realistic mode, Monte Carlo).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->