### PR TITLE
fix: add separate patience config for PPO training

### DIFF
--- a/config/example_config.json
+++ b/config/example_config.json
@@ -45,7 +45,8 @@
     "n_steps": 2048,
     "n_epochs": 10,
     "batch_size": 64,
-    "total_timesteps": 1000000
+    "total_timesteps": 1000000,
+    "patience": 15
   },
 
   "risk": {

--- a/config/my_config.json
+++ b/config/my_config.json
@@ -57,7 +57,8 @@
         "n_steps": 1024,
         "n_epochs": 10,
         "batch_size": 64,
-        "total_timesteps": 1000000
+        "total_timesteps": 1000000,
+        "patience": 12
     },
     "risk": {
         "max_position_size": 0.01,

--- a/config/settings.py
+++ b/config/settings.py
@@ -99,6 +99,7 @@ class PPOConfig:
     n_epochs: int = 10  # Epochs per update
     batch_size: int = 64
     total_timesteps: int = 1_000_000
+    patience: int = 15  # Early stopping patience (requires eval_env)
 
     # Online learning
     online_update_frequency: int = 500

--- a/main.py
+++ b/main.py
@@ -341,6 +341,7 @@ class LeapTradingSystem:
                 'agent_timesteps': agent_timesteps or self.config.ppo.total_timesteps,
                 'batch_size': self.config.transformer.batch_size,
                 'patience': self.config.transformer.patience,
+                'ppo_patience': self.config.ppo.patience,
                 'checkpoint_dir': os.path.join(self.config.base_dir, self.config.checkpoints_dir)
             },
             mlflow_tracker=self.mlflow_tracker

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -54,6 +54,8 @@ class ModelTrainer:
         self.agent_timesteps = self.config.get('agent_timesteps', 100000)
         self.batch_size = self.config.get('batch_size', 64)
         self.patience = self.config.get('patience', 15)
+        # PPO patience defaults to transformer patience for backward compatibility
+        self.ppo_patience = self.config.get('ppo_patience', self.patience)
 
         # Checkpointing
         self.checkpoint_dir = self.config.get('checkpoint_dir', './checkpoints')
@@ -179,9 +181,9 @@ class ModelTrainer:
         timesteps = total_timesteps or self.agent_timesteps
         start_time = time.time()
 
-        # Determine patience: explicit arg > config > default (15)
+        # Determine patience: explicit arg > ppo_patience config > default (15)
         if patience is None:
-            patience = self.patience
+            patience = self.ppo_patience
 
         # Allow patience=0 to disable early stopping
         effective_patience = patience if patience > 0 else None


### PR DESCRIPTION
Previously, PPO training used the transformer's patience value from config,
ignoring any patience value specified in the ppo section. This fix:

- Adds patience field to PPOConfig in config/settings.py
- Passes ppo_patience separately to ModelTrainer
- Updates trainer.py to use ppo_patience for agent training
- Updates example configs to include the new ppo.patience option

For backward compatibility, ppo_patience defaults to transformer patience
if not explicitly configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable patience parameter for PPO training. Users can now customize early stopping behavior by specifying how many steps the trainer should wait for performance improvements before terminating training.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->