### PR TITLE
Separate transformer and PPO training processes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,13 @@ Leap is an AI-powered forex trading system combining Transformer-based price pre
 ## Common Commands
 
 ```bash
-# Training
+# Training (both models)
 python main.py train --symbol EURUSD --epochs 100 --timesteps 100000
 python main.py train --symbols EURUSD GBPUSD --multi-timeframe  # Multi-symbol + multi-timeframe
+
+# Training (separate models)
+python main.py train-transformer --symbol EURUSD --epochs 100  # Transformer only
+python main.py train-ppo --symbol EURUSD --timesteps 100000    # PPO only (loads existing predictor)
 
 # Backtesting
 python main.py backtest --symbol EURUSD --realistic --monte-carlo


### PR DESCRIPTION
Add new CLI commands to train models independently:
- train-transformer: Train only the Transformer predictor model
- train-ppo: Train only the PPO agent (loads existing predictor if available)

Changes:
- Add train_transformer() and train_ppo() methods to LeapTradingSystem
- Add _save_predictor_metadata() and _save_agent_metadata() helper methods
- Update CLI parser with new commands (train-transformer, train-ppo)
- Add command handlers for separate model training
- Update CLI.md with full documentation for new commands
- Update CLAUDE.md with new command examples

This allows users to:
- Retrain just the price predictor without affecting the RL agent
- Retrain just the PPO agent without retraining prediction
- Experiment with different hyperparameters for each model independently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced separate training commands: `train-transformer` for Transformer models and `train-ppo` for PPO agents
  * Multi-symbol training with per-symbol model persistence and separate artifact management
  * Multi-timeframe support integrated into training workflows

* **Documentation**
  * Updated and expanded CLI documentation with new command syntax, options, and usage examples
  * Added detailed guidance for separate model training workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->