### PR TITLE
fix: rename test helper functions to avoid pytest fixture errors

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -55,8 +55,8 @@ def test_data_pipeline():
     return pipeline, market_data
 
 
-def test_transformer_predictor(input_dim: int):
-    """Test Transformer predictor model."""
+def _test_transformer_predictor(input_dim: int):
+    """Test Transformer predictor model (helper function, not a standalone test)."""
     print("\n" + "="*60)
     print("Testing Transformer Predictor...")
     print("="*60)
@@ -122,8 +122,8 @@ def test_transformer_predictor(input_dim: int):
     return predictor
 
 
-def test_ppo_agent(state_dim: int):
-    """Test PPO reinforcement learning agent."""
+def _test_ppo_agent(state_dim: int):
+    """Test PPO reinforcement learning agent (helper function, not a standalone test)."""
     print("\n" + "="*60)
     print("Testing PPO Agent...")
     print("="*60)
@@ -541,10 +541,10 @@ def test_full_integration():
     print(f"✓ State dimension: {state_dim}")
 
     # 4. Create and test predictor
-    predictor = test_transformer_predictor(input_dim)
+    predictor = _test_transformer_predictor(input_dim)
 
     # 5. Create and test agent
-    agent = test_ppo_agent(state_dim)
+    agent = _test_ppo_agent(state_dim)
 
     # 6. Test risk manager
     risk_manager = test_risk_manager()


### PR DESCRIPTION
## Summary
- Rename `test_transformer_predictor()` to `_test_transformer_predictor()` 
- Rename `test_ppo_agent()` to `_test_ppo_agent()`
- Update calls in `test_full_integration()` to use new names

Closes #92

## Problem
When running individual tests via pytest, these functions caused "fixture not found" errors:
```
E       fixture 'input_dim' not found
E       fixture 'state_dim' not found
```

This happened because:
1. Functions named `test_*` are auto-discovered by pytest
2. Their parameters (`input_dim`, `state_dim`) are interpreted as fixture names
3. No such fixtures exist - these parameters are meant to be passed from `test_full_integration()`

## Solution
Renamed the functions with underscore prefix (`_test_*`) to indicate they are internal helper functions. This:
- Follows Python convention for internal/private functions
- Tells pytest to skip them during test collection
- Preserves their functionality when called from `test_full_integration()`

## Test plan
- [x] `pytest tests/test_integration.py --collect-only` shows 9 tests (not 11)
- [x] `pytest tests/test_integration.py::test_full_integration -v` passes
- [x] Individual tests like `test_data_pipeline` run without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal test infrastructure reorganized for improved maintainability. No changes to application functionality or user-facing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->