### PR TITLE
fix: resolve tensor shape mismatch between training and inference (#101)

### DIFF
--- a/core/data_pipeline.py
+++ b/core/data_pipeline.py
@@ -1035,8 +1035,14 @@ class DataPipeline:
         # This creates a view without copying data
         from numpy.lib.stride_tricks import sliding_window_view
 
-        # Create sliding windows over features: shape (n_windows, seq_len, n_features)
+        # Create sliding windows over features
+        # sliding_window_view with axis=0 on (n_bars, n_features) produces (n_windows, n_features, seq_len)
+        # We need to transpose to get (n_windows, seq_len, n_features) for PyTorch models
         X = sliding_window_view(features, window_shape=sequence_length, axis=0)
+
+        # Transpose from (n_windows, n_features, seq_len) to (n_windows, seq_len, n_features)
+        # This matches the expected input format: (batch, seq_len, features)
+        X = X.transpose(0, 2, 1)
 
         # Select only the samples we need (excluding last prediction_horizon)
         X = X[:n_samples].copy()  # Copy to ensure contiguous array for training

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -45,9 +45,8 @@ def test_data_pipeline():
     )
 
     assert len(X) > 0, "Should create sequences"
-    # Note: sliding_window_view produces shape (samples, features, seq_len)
-    # The sequence length is at index 2, not index 1
-    assert X.shape[2] == 60, "Sequence length should be 60"
+    # Shape is (samples, seq_len, features) - standard PyTorch format
+    assert X.shape[1] == 60, "Sequence length should be 60"
     assert len(X) == len(y), "X and y should have same length"
 
     print(f"✓ Created {len(X)} sequences with shape {X.shape}")


### PR DESCRIPTION
## Summary

This PR fixes issue #101 where matrix multiplication errors occurred during backtest and inference due to tensor shape mismatches:

- **Prediction error**: `linear(): input and weight.T shapes cannot be multiplied (192x87 and 192x128)`
- **Agent error**: `linear(): input and weight.T shapes cannot be multiplied (1x10440 and 11048x256)`

## Root Causes and Fixes

### 1. Transpose bug in `prepare_sequences` (data_pipeline.py)
- `sliding_window_view` with `axis=0` on `(n_bars, n_features)` produces `(n_windows, n_features, seq_len)`
- **Fix**: Added transpose to get `(n_windows, seq_len, n_features)` for PyTorch models

### 2. Feature set mismatch (strategy.py)
- Training includes OHLCV + computed features (92 total)
- Inference was excluding OHLCV columns (only 87 computed features)
- **Fix**: Added `_get_feature_columns()` helper that always includes OHLCV columns first, matching training format

### 3. Missing account features for agent (strategy.py, backtester.py)
- Agent trained with 8 account features from `TradingEnvironment._get_account_observation()`
- Inference was only passing market features (11040) instead of market + account (11048)
- **Fix**: 
  - Added `_build_account_observation()` to construct 8 account features
  - Updated backtester to track and pass `account_state` to strategy

## Changes

| File | Change |
|------|--------|
| `core/data_pipeline.py` | Add transpose after `sliding_window_view` |
| `core/strategy.py` | Add `_get_feature_columns()`, `_build_account_observation()` |
| `evaluation/backtester.py` | Track account state, pass to strategy |
| `tests/test_integration.py` | Update shape assertion for corrected format |

## Test plan

- [x] All 324 tests pass
- [x] Train command completes without errors
- [x] Backtest command completes without errors (no dimension mismatch)
- [x] Strategy correctly builds observations with 92 features + 8 account features

## Verification

```bash
# Training
python main.py train --symbol EURUSD --epochs 1 --timesteps 500 --bars 300
# Output: Created 168 sequences with shape (168, 120, 92) ✓

# Backtest
python main.py backtest --symbol EURUSD --bars 300
# Output: Backtest complete. Total return: -4.25% ✓ (no dimension errors)
```

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Trading strategies now incorporate account state metrics (balance, equity, unrealized PnL, drawdown) for enhanced decision-making.
  * Improved feature consistency in model inference through explicit column ordering.

* **Chores**
  * Optimized internal data format alignment with PyTorch model expectations.
  * Updated integration tests to reflect data structure changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->